### PR TITLE
feat(frontend): add request tracking and replay control

### DIFF
--- a/src/core/Bundle.scala
+++ b/src/core/Bundle.scala
@@ -642,7 +642,7 @@ class FrontendIO(
     extends Bundle {
   val might_request = Output(Bool())
   val clock_enabled = Input(Bool())
-  val req = Valid(new FrontendReq(warpNum, vaddrBitsExtended))
+  val req = Decoupled(new FrontendReq(warpNum, vaddrBitsExtended))
   val sfence = Valid(new SFenceReq(vaddrBits, asidBits))
   val resp = Flipped(
     Decoupled(

--- a/src/core/Bundle.scala
+++ b/src/core/Bundle.scala
@@ -594,7 +594,7 @@ object CFIType {
 }
 
 class FrontendResp(
-  warpNum:        Int,
+  warpNum:           Int,
   vaddrBits:         Int,
   entries:           Int,
   bhtHistoryLength:  Option[Int],
@@ -630,7 +630,7 @@ class FrontendPerfEvents extends Bundle {
 }
 
 class FrontendIO(
-  warpNum:  Int, // Number of warps
+  warpNum:           Int, // Number of warps
   vaddrBitsExtended: Int,
   vaddrBits:         Int,
   asidBits:          Int,
@@ -670,7 +670,7 @@ class FrontendIO(
 
 // Non-diplomatic version of Frontend
 class FrontendBundle(
-  warpNum:  Int, // Number of warps
+  warpNum:           Int, // Number of warps
   vaddrBitsExtended: Int,
   vaddrBits:         Int,
   asidBits:          Int,
@@ -691,7 +691,7 @@ class FrontendBundle(
     extends Bundle {
   val cpu = Flipped(
     new FrontendIO(
-  warpNum,
+      warpNum,
       vaddrBitsExtended,
       vaddrBits,
       asidBits,

--- a/src/core/FetchQueue.scala
+++ b/src/core/FetchQueue.scala
@@ -41,9 +41,9 @@ case class FetchQueueParameter(
 class FetchQueueInterface(parameter: FetchQueueParameter) extends Bundle {
   val clock = Input(Clock())
   val reset = Input(if (parameter.useAsyncReset) AsyncReset() else Bool())
-  val enq   = Flipped(Decoupled(parameter.gen))
-  val deq   = Decoupled(parameter.gen)
-  val mask  = Output(UInt(parameter.entries.W))
+  val enq = Flipped(Decoupled(parameter.gen))
+  val deq = Decoupled(parameter.gen)
+  val mask = Output(UInt(parameter.entries.W))
 }
 
 @instantiable
@@ -57,14 +57,14 @@ class FetchQueue(val parameter: FetchQueueParameter)
   override protected def implicitReset: Reset = io.reset
 
   private val valid = RegInit(VecInit(Seq.fill(parameter.entries) { false.B }))
-  private val elts  = Reg(Vec(parameter.entries, parameter.gen))
+  private val elts = Reg(Vec(parameter.entries, parameter.gen))
 
   for (i <- 0 until parameter.entries) {
     def paddedValid(i: Int) = if (i == -1) true.B else if (i == parameter.entries) false.B else valid(i)
 
-    val flow  = true
+    val flow = true
     val wdata = if (i == parameter.entries - 1) io.enq.bits else Mux(valid(i + 1), elts(i + 1), io.enq.bits)
-    val wen   =
+    val wen =
       Mux(
         io.deq.ready,
         paddedValid(i + 1) || io.enq.fire && valid(i),
@@ -82,7 +82,7 @@ class FetchQueue(val parameter: FetchQueueParameter)
 
   io.enq.ready := !valid(parameter.entries - 1)
   io.deq.valid := valid(0)
-  io.deq.bits  := elts.head
+  io.deq.bits := elts.head
 
   when(io.enq.valid) { io.deq.valid := true.B }
   when(!valid(0)) { io.deq.bits := io.enq.bits }

--- a/src/core/Frontend.scala
+++ b/src/core/Frontend.scala
@@ -320,7 +320,7 @@ class Frontend(val parameter: FrontendParameter)
         (!fq.io.mask(fq.io.mask.getWidth - 2) && (!s1_valid || !s2_valid)) ||
         (!fq.io.mask(fq.io.mask.getWidth - 1) && (!s1_valid && !s2_valid))
 
-    val s0_valid = (io.nonDiplomatic.cpu.req.valid && !req_processed  || need_replay)&& s0_fq_has_space
+    val s0_valid = (io.nonDiplomatic.cpu.req.valid && !req_processed || need_replay) && s0_fq_has_space
     s1_valid := s0_valid
     val s1_pc = Reg(UInt(vaddrBitsExtended.W))
     val s1_wid = Reg(UInt(log2Ceil(warpNum).W))
@@ -351,7 +351,7 @@ class Frontend(val parameter: FrontendParameter)
     s1_wid := io.nonDiplomatic.cpu.req.bits.wid
 
     io.nonDiplomatic.cpu.req.ready := !req_processed && !need_replay && s0_fq_has_space
-     when(s0_valid) {
+    when(s0_valid) {
       need_replay := false.B
     }.elsewhen(s2_valid && !fq.io.enq.fire) {
       need_replay := true.B
@@ -436,7 +436,7 @@ class Frontend(val parameter: FrontendParameter)
     fq.io.enq.bits.xcpt.ae := s2_tlb_resp.ae.inst
     fq.io.enq.bits.xcpt.gf := false.B
     fq.io.enq.bits.xcpt.pf := s2_tlb_resp.pf.inst
-    //TODO
+    // TODO
     fq.io.enq.bits.wid := 0.U
 
     //     assert(

--- a/src/core/Frontend.scala
+++ b/src/core/Frontend.scala
@@ -436,8 +436,6 @@ class Frontend(val parameter: FrontendParameter)
     fq.io.enq.bits.xcpt.ae := s2_tlb_resp.ae.inst
     fq.io.enq.bits.xcpt.gf := false.B
     fq.io.enq.bits.xcpt.pf := s2_tlb_resp.pf.inst
-    // TODO
-    fq.io.enq.bits.wid := 0.U
 
     //     assert(
     //       !(s2_speculative && io.ptw.customCSRs

--- a/tests/FrontendTest.scala
+++ b/tests/FrontendTest.scala
@@ -61,6 +61,7 @@ class FrontendTest extends AnyFlatSpec {
       dut.io.resetVector.poke(0x1000.U)
       dut.io.nonDiplomatic.cpu.might_request.poke(true.B)
       dut.io.nonDiplomatic.cpu.req.valid.poke(false.B)
+      dut.io.nonDiplomatic.cpu.req.bits.wid.poke(2.U)
       dut.io.nonDiplomatic.ptw.status.prv.poke(3.U)
       dut.io.nonDiplomatic.ptw.status.v.poke(false.B)
 

--- a/tests/FrontendTest.scala
+++ b/tests/FrontendTest.scala
@@ -80,7 +80,7 @@ class FrontendTest extends AnyFlatSpec {
       dut.io.instructionFetchAXI.ar.ready.poke(true.B)
 
       var i = 0
-      while (dut.io.instructionFetchAXI.ar.valid.peek().litToBoolean == true) {
+      while (dut.io.instructionFetchAXI.ar.valid.peek().litToBoolean == true && i < 100) {
         i = i + 1
         dut.io.clock.step()
       }
@@ -92,8 +92,9 @@ class FrontendTest extends AnyFlatSpec {
       dut.io.instructionFetchAXI.r.bits.last.poke(true.B)
       dut.io.clock.step()
       dut.io.instructionFetchAXI.r.valid.poke(false.B)
-      while (dut.io.nonDiplomatic.cpu.resp.valid.peek().litToBoolean == false) {
+      while (dut.io.nonDiplomatic.cpu.resp.valid.peek().litToBoolean == false && i < 200) {
         dut.io.clock.step()
+        i = i + 1
       }
       dut.io.nonDiplomatic.cpu.resp.bits.pc.expect(0x1000.U)
       dut.io.nonDiplomatic.cpu.resp.bits.data.expect("hdeadbeef".U)


### PR DESCRIPTION
The change is for GPU
- Cancel prefetch request from fetch queue
- cpu request is decoupled
- Add req_processed register to track request completion status
- Add need_replay register for fetch retry handling
- Implement request ready logic based on processing state
- Control request processing with fetch queue status
- Ensure single fetch per request through state tracking
- Clean up request handling in gated clock domain

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report | feature request | other enhancement

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code) | API modification

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
