### PR TITLE
feat(warpfrontend): implement round-robin instruction selection

### DIFF
--- a/src/core/WarpFrontend.scala
+++ b/src/core/WarpFrontend.scala
@@ -85,27 +85,20 @@ class WarpFrontend(val parameter: WarpFrontendParameter)
   override protected def implicitClock: Clock = io.clock
   override protected def implicitReset: Reset = io.reset
 
-  object State extends ChiselEnum {
-    val Idle, WaitInit, Fetching, WaitBranch = Value
-  }
-  import State._
 
   // State registers
-  val state = RegInit(Idle)
   val warpActive = RegInit(VecInit(Seq.fill(parameter.warpNum)(false.B)))
   val warpBlocked = RegInit(VecInit(Seq.fill(parameter.warpNum)(false.B)))
   val warpPC = Reg(Vec(parameter.warpNum, UInt(parameter.vaddrBitsExtended.W)))
-  val currentWarp = Reg(UInt(log2Ceil(parameter.warpNum).W))
-
-  // Control signals
-  val fetchValid = RegInit(false.B)
 
   // Default values
-  io.warp_start.ready := state === Idle
   io.frontend_req.valid := false.B
   io.frontend_req.bits.pc := 0.U
   io.frontend_req.bits.wid := 0.U
   io.decode.valid := false.B
+
+  // Default values - simplify ready signal
+  io.warp_start.ready := !warpActive.reduce(_ && _) // True if not all warps are active
 
   // Round-robin arbiter for warp selection
   val warpArbiter = Module(
@@ -146,7 +139,6 @@ class WarpFrontend(val parameter: WarpFrontendParameter)
   val branchPending = RegInit(VecInit(Seq.fill(parameter.warpNum)(false.B)))
 
   // Default values
-  io.warp_start.ready := true.B
   io.frontend_req.valid := false.B
   io.decode.valid := false.B
   io.frontend_resp.ready := false.B // Add default value
@@ -204,29 +196,36 @@ class WarpFrontend(val parameter: WarpFrontendParameter)
     }
   }
 
-  // Issue instruction from selected warp
-  when(validWarpSelected && io.decode.ready) {
-    // Create one-hot encoding for selectedWarp
-    val selectedWarpOH = UIntToOH(selectedWarp)
+  // Add buffer arbiter
+  val bufferArbiter = Module(new RRArbiter(new Bundle {
+    val inst = UInt(parameter.coreInstBits.W)
+    val pc = UInt(parameter.vaddrBitsExtended.W)
+    val wid = UInt(log2Ceil(parameter.warpNum).W)
+  }, parameter.warpNum))
 
-    // Valid and data signals for all buffers
-    val bufferValids = VecInit(instBuffers.map(_.io.deq.valid))
-    val bufferInsts = VecInit(instBuffers.map(_.io.deq.bits.inst))
-    val bufferPCs = VecInit(instBuffers.map(_.io.deq.bits.pc))
-
-    // Select buffer outputs using Mux1H
-    when(Mux1H(selectedWarpOH, bufferValids)) {
-      io.decode.valid := true.B
-      io.decode.bits.inst := Mux1H(selectedWarpOH, bufferInsts)
-      io.decode.bits.pc := Mux1H(selectedWarpOH, bufferPCs)
-      io.decode.bits.wid := selectedWarp
-
-      // Set ready for selected buffer
-      for (i <- 0 until parameter.warpNum) {
-        instBuffers(i).io.deq.ready := selectedWarpOH(i)
-      }
-    }
+  // Connect buffer outputs to arbiter inputs
+  for (i <- 0 until parameter.warpNum) {
+    bufferArbiter.io.in(i).valid := instBuffers(i).io.deq.valid && 
+                                   warpActive(i) && 
+                                   !warpBlocked(i)
+    bufferArbiter.io.in(i).bits.inst := instBuffers(i).io.deq.bits.inst
+    bufferArbiter.io.in(i).bits.pc := instBuffers(i).io.deq.bits.pc
+    bufferArbiter.io.in(i).bits.wid := i.U
+    
+    // Connect dequeue ready signals
+    instBuffers(i).io.deq.ready := bufferArbiter.io.in(i).ready && 
+                                  bufferArbiter.io.in(i).valid
   }
+
+  // Connect arbiter to decode interface
+  bufferArbiter.io.out.ready := io.decode.ready
+  io.decode.valid := bufferArbiter.io.out.valid
+  io.decode.bits.inst := bufferArbiter.io.out.bits.inst
+  io.decode.bits.pc := bufferArbiter.io.out.bits.pc
+  io.decode.bits.wid := bufferArbiter.io.out.bits.wid
+
+  // Remove old instruction issue logic
+  // when(validWarpSelected && io.decode.ready) { ... }
 
   // Branch handling
   when(io.decode_branch) {

--- a/tests/WarpFrontendTest.scala
+++ b/tests/WarpFrontendTest.scala
@@ -1,0 +1,147 @@
+package ogpu.core
+
+import chisel3._
+import org.scalatest.flatspec.AnyFlatSpec
+import chisel3.simulator.VCDHackedEphemeralSimulator._
+
+class WarpFrontendTest extends AnyFlatSpec {
+  val param = WarpFrontendParameter(
+    useAsyncReset = false,
+    clockGate = false,
+    warpNum = 4,
+    vaddrBits = 32,
+    vaddrBitsExtended = 32,
+    entries = 2,
+    coreInstBits = 32,
+    fetchWidth = 4,
+    fetchBufferSize = 4
+  )
+
+  behavior.of("WarpFront")
+
+  it should "handle basic instruction fetch correctly" in {
+    simulate(new WarpFrontend(param), "warpfrontend_fetch") { dut =>
+      // Initialize
+      dut.io.clock.step()
+      dut.io.reset.poke(true.B)
+      dut.io.clock.step()
+      dut.io.reset.poke(false.B)
+      dut.io.reg_init_done.poke(false.B)
+      dut.io.decode_branch.poke(false.B)
+
+      // Start warp
+      dut.io.warp_start.valid.poke(true.B)
+      dut.io.warp_start.bits.wid.poke(0.U)
+      dut.io.warp_start.bits.pc.poke("h1000".U)
+      dut.io.clock.step()
+      dut.io.warp_start.valid.poke(false.B)
+
+      // Signal register initialization done
+      dut.io.reg_init_done.poke(true.B)
+      dut.io.clock.step()
+
+      // Check frontend request
+      dut.io.frontend_req.valid.expect(true.B)
+      dut.io.frontend_req.bits.pc.expect("h1000".U)
+      dut.io.frontend_req.bits.wid.expect(0.U)
+      dut.io.clock.step()
+
+      // Provide frontend response
+      dut.io.frontend_resp.valid.poke(true.B)
+      dut.io.frontend_resp.bits.data.poke("h_dead_beef".U)
+      dut.io.frontend_resp.bits.pc.poke("h1000".U)
+      dut.io.frontend_resp.bits.wid.poke(0.U)
+      dut.io.clock.step()
+      dut.io.frontend_resp.valid.poke(false.B)
+      dut.io.clock.step(5)
+
+      // Check decoder output
+      dut.io.decode.valid.expect(true.B)
+      dut.io.decode.bits.inst.expect("hdeadbeef".U)
+      dut.io.decode.bits.pc.expect("h1000".U)
+      dut.io.decode.bits.wid.expect(0.U)
+    }
+  }
+
+  // it should "handle branch instructions correctly" in {
+  //   simulate(new WarpFrontend(param), "warpfrontend_branch") { dut =>
+  //     // Initialize
+  //     dut.io.clock.step()
+  //     dut.io.reset.poke(true.B)
+  //     dut.io.clock.step()
+  //     dut.io.reset.poke(false.B)
+  //     dut.io.reg_init_done.poke(true.B)
+
+  //     // Start warp
+  //     dut.io.warp_start.valid.poke(true.B)
+  //     dut.io.warp_start.bits.wid.poke(0.U)
+  //     dut.io.warp_start.bits.pc.poke("h1000".U)
+  //     dut.io.clock.step()
+  //     dut.io.warp_start.valid.poke(false.B)
+
+  //     // Simulate normal fetch
+  //     dut.io.frontend_resp.valid.poke(true.B)
+  //     dut.io.frontend_resp.bits.data.poke("hbeef0000".U)
+  //     dut.io.frontend_resp.bits.pc.poke("h1000".U)
+  //     dut.io.clock.step()
+
+  //     // Signal branch instruction
+  //     dut.io.decode_branch.poke(true.B)
+  //     dut.io.clock.step()
+  //     dut.io.decode_branch.poke(false.B)
+
+  //     // Verify fetch stops
+  //     dut.io.frontend_req.valid.expect(false.B)
+
+  //     // Provide branch resolution
+  //     dut.io.branch_update.valid.poke(true.B)
+  //     dut.io.branch_update.bits.wid.poke(0.U)
+  //     dut.io.branch_update.bits.pc.poke("h1000".U)
+  //     dut.io.branch_update.bits.target.poke("h2000".U)
+  //     dut.io.clock.step()
+  //     dut.io.branch_update.valid.poke(false.B)
+
+  //     // Verify fetch resumes from new target
+  //     dut.io.frontend_req.valid.expect(true.B)
+  //     dut.io.frontend_req.bits.pc.expect("h2000".U)
+  //   }
+  // }
+
+  // it should "handle multiple warps correctly" in {
+  //   simulate(new WarpFrontend(param), "warpfrontend_multiwarps") { dut =>
+  //     // Initialize
+  //     dut.io.clock.step()
+  //     dut.io.reset.poke(true.B)
+  //     dut.io.clock.step()
+  //     dut.io.reset.poke(false.B)
+  //     dut.io.reg_init_done.poke(true.B)
+
+  //     // Start first warp
+  //     dut.io.warp_start.valid.poke(true.B)
+  //     dut.io.warp_start.bits.wid.poke(0.U)
+  //     dut.io.warp_start.bits.pc.poke("h1000".U)
+  //     dut.io.clock.step()
+
+  //     // Start second warp
+  //     dut.io.warp_start.bits.wid.poke(1.U)
+  //     dut.io.warp_start.bits.pc.poke("h2000".U)
+  //     dut.io.clock.step()
+  //     dut.io.warp_start.valid.poke(false.B)
+
+  //     // Verify both warps are handled
+  //     dut.io.frontend_req.bits.wid.expect(0.U)
+  //     dut.io.frontend_req.bits.pc.expect("h1000".U)
+
+  //     // Provide response for first warp
+  //     dut.io.frontend_resp.valid.poke(true.B)
+  //     dut.io.frontend_resp.bits.data.poke("h11111111".U)
+  //     dut.io.frontend_resp.bits.pc.poke("h1000".U)
+  //     dut.io.frontend_resp.bits.wid.poke(0.U)
+  //     dut.io.clock.step()
+
+  //     // Check second warp
+  //     dut.io.frontend_req.bits.wid.expect(1.U)
+  //     dut.io.frontend_req.bits.pc.expect("h2000".U)
+  //   }
+  // }
+}


### PR DESCRIPTION
- Add RRArbiter for instruction buffer output selection
- Remove direct instruction issue logic
- Update buffer connections to use arbiter interface
- Fix warp activation control based on available slots
- Remove unused state machine and related signals
- Update default signal assignments
- Add buffer flow control with ready/valid handshaking
- add a simple unit test case

The changes improve fairness in instruction scheduling across warps and simplify the control flow logic.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report | feature request | other enhancement

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code) | API modification

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
