### PR TITLE
fix(warpfront): Ensure warp unblocks correctly after instruction fetc…

### DIFF
--- a/tests/WarpFrontendTest.scala
+++ b/tests/WarpFrontendTest.scala
@@ -27,7 +27,6 @@ class WarpFrontendTest extends AnyFlatSpec {
       dut.io.clock.step()
       dut.io.reset.poke(false.B)
       dut.io.reg_init_done.poke(false.B)
-      dut.io.decode_branch.poke(false.B)
 
       // Start warp
       dut.io.warp_start.valid.poke(true.B)
@@ -63,85 +62,79 @@ class WarpFrontendTest extends AnyFlatSpec {
     }
   }
 
-  // it should "handle branch instructions correctly" in {
-  //   simulate(new WarpFrontend(param), "warpfrontend_branch") { dut =>
-  //     // Initialize
-  //     dut.io.clock.step()
-  //     dut.io.reset.poke(true.B)
-  //     dut.io.clock.step()
-  //     dut.io.reset.poke(false.B)
-  //     dut.io.reg_init_done.poke(true.B)
+  it should "handle branch instructions correctly" in {
+    simulate(new WarpFrontend(param), "warpfrontend_branch") { dut =>
+      // Initialize
+      dut.io.clock.step()
+      dut.io.reset.poke(true.B)
+      dut.io.clock.step()
+      dut.io.reset.poke(false.B)
+      dut.io.reg_init_done.poke(true.B)
+      dut.io.frontend_req.ready.poke(true.B)
 
-  //     // Start warp
-  //     dut.io.warp_start.valid.poke(true.B)
-  //     dut.io.warp_start.bits.wid.poke(0.U)
-  //     dut.io.warp_start.bits.pc.poke("h1000".U)
-  //     dut.io.clock.step()
-  //     dut.io.warp_start.valid.poke(false.B)
+      // Start warp
+      dut.io.warp_start.valid.poke(true.B)
+      dut.io.warp_start.bits.wid.poke(0.U)
+      dut.io.warp_start.bits.pc.poke("h1000".U)
+      dut.io.clock.step()
+      dut.io.warp_start.valid.poke(false.B)
+      dut.io.clock.step(5)
 
-  //     // Simulate normal fetch
-  //     dut.io.frontend_resp.valid.poke(true.B)
-  //     dut.io.frontend_resp.bits.data.poke("hbeef0000".U)
-  //     dut.io.frontend_resp.bits.pc.poke("h1000".U)
-  //     dut.io.clock.step()
+      // Simulate normal fetch
+      dut.io.frontend_resp.valid.poke(true.B)
+      dut.io.frontend_resp.bits.data.poke("hbeef0000".U)
+      dut.io.frontend_resp.bits.pc.poke("h1000".U)
+      dut.io.clock.step()
+      dut.io.frontend_resp.valid.poke(false.B)
 
-  //     // Signal branch instruction
-  //     dut.io.decode_branch.poke(true.B)
-  //     dut.io.clock.step()
-  //     dut.io.decode_branch.poke(false.B)
+      // Verify fetch stops
+      dut.io.frontend_req.valid.expect(false.B)
 
-  //     // Verify fetch stops
-  //     dut.io.frontend_req.valid.expect(false.B)
+      // Provide branch resolution
+      dut.io.branch_update.valid.poke(true.B)
+      dut.io.branch_update.bits.wid.poke(0.U)
+      dut.io.branch_update.bits.pc.poke("h1000".U)
+      dut.io.branch_update.bits.target.poke("h2000".U)
+      dut.io.clock.step()
+      dut.io.branch_update.valid.poke(false.B)
 
-  //     // Provide branch resolution
-  //     dut.io.branch_update.valid.poke(true.B)
-  //     dut.io.branch_update.bits.wid.poke(0.U)
-  //     dut.io.branch_update.bits.pc.poke("h1000".U)
-  //     dut.io.branch_update.bits.target.poke("h2000".U)
-  //     dut.io.clock.step()
-  //     dut.io.branch_update.valid.poke(false.B)
+      // Verify fetch resumes from new target
+      dut.io.frontend_req.valid.expect(true.B)
+      dut.io.frontend_req.bits.pc.expect("h2000".U)
+    }
+  }
 
-  //     // Verify fetch resumes from new target
-  //     dut.io.frontend_req.valid.expect(true.B)
-  //     dut.io.frontend_req.bits.pc.expect("h2000".U)
-  //   }
-  // }
+  it should "handle multiple warps correctly" in {
+    simulate(new WarpFrontend(param), "warpfrontend_multiwarps") { dut =>
+      // Initialize
+      dut.io.clock.step()
+      dut.io.reset.poke(true.B)
+      dut.io.clock.step()
+      dut.io.reset.poke(false.B)
+      dut.io.reg_init_done.poke(true.B)
 
-  // it should "handle multiple warps correctly" in {
-  //   simulate(new WarpFrontend(param), "warpfrontend_multiwarps") { dut =>
-  //     // Initialize
-  //     dut.io.clock.step()
-  //     dut.io.reset.poke(true.B)
-  //     dut.io.clock.step()
-  //     dut.io.reset.poke(false.B)
-  //     dut.io.reg_init_done.poke(true.B)
+      // Start first warp
+      dut.io.warp_start.valid.poke(true.B)
+      dut.io.warp_start.bits.wid.poke(0.U)
+      dut.io.warp_start.bits.pc.poke("h1000".U)
+      dut.io.clock.step()
 
-  //     // Start first warp
-  //     dut.io.warp_start.valid.poke(true.B)
-  //     dut.io.warp_start.bits.wid.poke(0.U)
-  //     dut.io.warp_start.bits.pc.poke("h1000".U)
-  //     dut.io.clock.step()
+      // Start second warp
+      dut.io.warp_start.bits.wid.poke(1.U)
+      dut.io.warp_start.bits.pc.poke("h2000".U)
+      dut.io.clock.step()
+      dut.io.warp_start.valid.poke(false.B)
 
-  //     // Start second warp
-  //     dut.io.warp_start.bits.wid.poke(1.U)
-  //     dut.io.warp_start.bits.pc.poke("h2000".U)
-  //     dut.io.clock.step()
-  //     dut.io.warp_start.valid.poke(false.B)
+      // Provide response for first warp
+      dut.io.frontend_resp.valid.poke(true.B)
+      dut.io.frontend_resp.bits.data.poke("h11111111".U)
+      dut.io.frontend_resp.bits.pc.poke("h1000".U)
+      dut.io.frontend_resp.bits.wid.poke(0.U)
+      dut.io.clock.step()
 
-  //     // Verify both warps are handled
-  //     dut.io.frontend_req.bits.wid.expect(0.U)
-  //     dut.io.frontend_req.bits.pc.expect("h1000".U)
-
-  //     // Provide response for first warp
-  //     dut.io.frontend_resp.valid.poke(true.B)
-  //     dut.io.frontend_resp.bits.data.poke("h11111111".U)
-  //     dut.io.frontend_resp.bits.pc.poke("h1000".U)
-  //     dut.io.frontend_resp.bits.wid.poke(0.U)
-  //     dut.io.clock.step()
-
-  //     // Check second warp
-  //     dut.io.frontend_req.bits.wid.expect(1.U)
-  //     dut.io.frontend_req.bits.pc.expect("h2000".U)
-  //   }
-  // }
+      // Check second warp
+      dut.io.frontend_req.bits.wid.expect(1.U)
+      dut.io.frontend_req.bits.pc.expect("h2000".U)
+    }
+  }
 }


### PR DESCRIPTION
…h completion

Previously, warps were incorrectly blocked indefinitely after issuing an instruction fetch. This has been resolved by:
1. Unblocking warps when the decoder completes processing an activate instruction
2. Properly unblocking warps after branch instruction execution finishes

This change ensures warp execution resumes correctly following control flow changes and activation operations.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report | feature request | other enhancement

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code) | API modification

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
